### PR TITLE
Zig 0.12 updates

### DIFF
--- a/package/zig-builtins/dec.zig
+++ b/package/zig-builtins/dec.zig
@@ -32,7 +32,7 @@ pub const RocDec = extern struct {
     }
 
     pub fn fromF64(num: f64) ?RocDec {
-        var result: f64 = num * comptime @as(f64, @floatFromInt(one_point_zero_i128));
+        const result: f64 = num * comptime @as(f64, @floatFromInt(one_point_zero_i128));
 
         if (result > comptime @as(f64, @floatFromInt(math.maxInt(i128)))) {
             return null;
@@ -42,7 +42,7 @@ pub const RocDec = extern struct {
             return null;
         }
 
-        var ret: RocDec = .{ .num = @as(i128, @intFromFloat(result)) };
+        const ret: RocDec = .{ .num = @as(i128, @intFromFloat(result)) };
         return ret;
     }
 
@@ -61,13 +61,13 @@ pub const RocDec = extern struct {
 
         const roc_str_slice = roc_str.asSlice();
 
-        var is_negative: bool = roc_str_slice[0] == '-';
-        var initial_index: usize = if (is_negative) 1 else 0;
+        const is_negative: bool = roc_str_slice[0] == '-';
+        const initial_index: usize = if (is_negative) 1 else 0;
 
         var point_index: ?usize = null;
         var index: usize = initial_index;
         while (index < length) {
-            var byte: u8 = roc_str_slice[index];
+            const byte: u8 = roc_str_slice[index];
             if (byte == '.' and point_index == null) {
                 point_index = index;
                 index += 1;
@@ -85,20 +85,20 @@ pub const RocDec = extern struct {
         if (point_index) |pi| {
             before_str_length = pi;
 
-            var after_str_len = (length - 1) - pi;
+            const after_str_len = (length - 1) - pi;
             if (after_str_len > decimal_places) {
                 // TODO: runtime exception for too many decimal places!
                 return null;
             }
-            var diff_decimal_places = decimal_places - after_str_len;
+            const diff_decimal_places = decimal_places - after_str_len;
 
-            var after_str = roc_str_slice[pi + 1 .. length];
-            var after_u64 = std.fmt.parseUnsigned(u64, after_str, 10) catch null;
+            const after_str = roc_str_slice[pi + 1 .. length];
+            const after_u64 = std.fmt.parseUnsigned(u64, after_str, 10) catch null;
             after_val_i128 = if (after_u64) |f| @as(i128, @intCast(f)) * math.pow(i128, 10, diff_decimal_places) else null;
         }
 
-        var before_str = roc_str_slice[initial_index..before_str_length];
-        var before_val_not_adjusted = std.fmt.parseUnsigned(i128, before_str, 10) catch null;
+        const before_str = roc_str_slice[initial_index..before_str_length];
+        const before_val_not_adjusted = std.fmt.parseUnsigned(i128, before_str, 10) catch null;
 
         var before_val_i128: ?i128 = null;
         if (before_val_not_adjusted) |before| {
@@ -115,7 +115,7 @@ pub const RocDec = extern struct {
         const dec: RocDec = blk: {
             if (before_val_i128) |before| {
                 if (after_val_i128) |after| {
-                    var answer = @addWithOverflow(before, after);
+                    const answer = @addWithOverflow(before, after);
                     const result = answer[0];
                     const overflowed = answer[1];
                     if (overflowed == 1) {
@@ -239,7 +239,7 @@ pub const RocDec = extern struct {
     }
 
     pub fn negate(self: RocDec) ?RocDec {
-        var negated = math.negate(self.num) catch null;
+        const negated = math.negate(self.num) catch null;
         return if (negated) |n| .{ .num = n } else null;
     }
 
@@ -779,8 +779,8 @@ fn div_u256_by_u128(numer: U256, denom: u128) U256 {
         // K X
         // ---
         // 0 K
-        var denom_leading_zeros = @clz(denom);
-        var numer_hi_leading_zeros = @clz(numer.hi);
+        const denom_leading_zeros = @clz(denom);
+        const numer_hi_leading_zeros = @clz(numer.hi);
         sr = 1 + N_UDWORD_BITS + denom_leading_zeros - numer_hi_leading_zeros;
         // 2 <= sr <= N_UTWORD_BITS - 1
         // q.all = n.all << (N_UTWORD_BITS - sr);
@@ -857,7 +857,7 @@ fn div_u256_by_u128(numer: U256, denom: u128) U256 {
         //
         // As an implementation of `as_u256`, we wrap a negative value around to the maximum value of U256.
 
-        var s_u128 = math.shr(u128, hi, 127);
+        const s_u128 = math.shr(u128, hi, 127);
         var s_hi: u128 = undefined;
         var s_lo: u128 = undefined;
         if (s_u128 == 1) {
@@ -867,7 +867,7 @@ fn div_u256_by_u128(numer: U256, denom: u128) U256 {
             s_hi = 0;
             s_lo = 0;
         }
-        var s = .{
+        const s = .{
             .hi = s_hi,
             .lo = s_lo,
         };
@@ -885,8 +885,8 @@ fn div_u256_by_u128(numer: U256, denom: u128) U256 {
         sr -= 1;
     }
 
-    var hi = (q.hi << 1) | (q.lo >> (127));
-    var lo = (q.lo << 1) | carry;
+    const hi = (q.hi << 1) | (q.lo >> (127));
+    const lo = (q.lo << 1) | carry;
 
     return .{ .hi = hi, .lo = lo };
 }
@@ -898,122 +898,122 @@ const expectEqualSlices = testing.expectEqualSlices;
 const expect = testing.expect;
 
 test "fromU64" {
-    var dec = RocDec.fromU64(25);
+    const dec = RocDec.fromU64(25);
 
     try expectEqual(RocDec{ .num = 25000000000000000000 }, dec);
 }
 
 test "fromF64" {
-    var dec = RocDec.fromF64(25.5);
+    const dec = RocDec.fromF64(25.5);
     try expectEqual(RocDec{ .num = 25500000000000000000 }, dec.?);
 }
 
 test "fromF64 overflow" {
-    var dec = RocDec.fromF64(1e308);
+    const dec = RocDec.fromF64(1e308);
     try expectEqual(dec, null);
 }
 
 test "fromStr: empty" {
-    var roc_str = RocStr.init("", 0);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init("", 0);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(dec, null);
 }
 
 test "fromStr: 0" {
-    var roc_str = RocStr.init("0", 1);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init("0", 1);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(RocDec{ .num = 0 }, dec.?);
 }
 
 test "fromStr: 1" {
-    var roc_str = RocStr.init("1", 1);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init("1", 1);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(RocDec.one_point_zero, dec.?);
 }
 
 test "fromStr: 123.45" {
-    var roc_str = RocStr.init("123.45", 6);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init("123.45", 6);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(RocDec{ .num = 123450000000000000000 }, dec.?);
 }
 
 test "fromStr: .45" {
-    var roc_str = RocStr.init(".45", 3);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init(".45", 3);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(RocDec{ .num = 450000000000000000 }, dec.?);
 }
 
 test "fromStr: 0.45" {
-    var roc_str = RocStr.init("0.45", 4);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init("0.45", 4);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(RocDec{ .num = 450000000000000000 }, dec.?);
 }
 
 test "fromStr: 123" {
-    var roc_str = RocStr.init("123", 3);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init("123", 3);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(RocDec{ .num = 123000000000000000000 }, dec.?);
 }
 
 test "fromStr: -.45" {
-    var roc_str = RocStr.init("-.45", 4);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init("-.45", 4);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(RocDec{ .num = -450000000000000000 }, dec.?);
 }
 
 test "fromStr: -0.45" {
-    var roc_str = RocStr.init("-0.45", 5);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init("-0.45", 5);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(RocDec{ .num = -450000000000000000 }, dec.?);
 }
 
 test "fromStr: -123" {
-    var roc_str = RocStr.init("-123", 4);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init("-123", 4);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(RocDec{ .num = -123000000000000000000 }, dec.?);
 }
 
 test "fromStr: -123.45" {
-    var roc_str = RocStr.init("-123.45", 7);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init("-123.45", 7);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(RocDec{ .num = -123450000000000000000 }, dec.?);
 }
 
 test "fromStr: abc" {
-    var roc_str = RocStr.init("abc", 3);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init("abc", 3);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(dec, null);
 }
 
 test "fromStr: 123.abc" {
-    var roc_str = RocStr.init("123.abc", 7);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init("123.abc", 7);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(dec, null);
 }
 
 test "fromStr: abc.123" {
-    var roc_str = RocStr.init("abc.123", 7);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init("abc.123", 7);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(dec, null);
 }
 
 test "fromStr: .123.1" {
-    var roc_str = RocStr.init(".123.1", 6);
-    var dec = RocDec.fromStr(roc_str);
+    const roc_str = RocStr.init(".123.1", 6);
+    const dec = RocDec.fromStr(roc_str);
 
     try expectEqual(dec, null);
 }
@@ -1226,46 +1226,46 @@ test "div: 20 / 2" {
 
 test "div: 8 / 5" {
     var dec: RocDec = RocDec.fromU64(8);
-    var res: RocDec = RocDec.fromStr(RocStr.init("1.6", 3)).?;
+    const res: RocDec = RocDec.fromStr(RocStr.init("1.6", 3)).?;
     try expectEqual(res, dec.div(RocDec.fromU64(5)));
 }
 
 test "div: 10 / 3" {
     var numer: RocDec = RocDec.fromU64(10);
-    var denom: RocDec = RocDec.fromU64(3);
+    const denom: RocDec = RocDec.fromU64(3);
 
     var roc_str = RocStr.init("3.333333333333333333", 20);
     errdefer roc_str.decref();
     defer roc_str.decref();
 
-    var res: RocDec = RocDec.fromStr(roc_str).?;
+    const res: RocDec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(res, numer.div(denom));
 }
 
 test "div: 341 / 341" {
     var number1: RocDec = RocDec.fromU64(341);
-    var number2: RocDec = RocDec.fromU64(341);
+    const number2: RocDec = RocDec.fromU64(341);
     try expectEqual(RocDec.fromU64(1), number1.div(number2));
 }
 
 test "div: 342 / 343" {
-    var number1: RocDec = RocDec.fromU64(342);
-    var number2: RocDec = RocDec.fromU64(343);
-    var roc_str = RocStr.init("0.997084548104956268", 20);
+    const number1: RocDec = RocDec.fromU64(342);
+    const number2: RocDec = RocDec.fromU64(343);
+    const roc_str = RocStr.init("0.997084548104956268", 20);
     try expectEqual(RocDec.fromStr(roc_str), number1.div(number2));
 }
 
 test "div: 680 / 340" {
     var number1: RocDec = RocDec.fromU64(680);
-    var number2: RocDec = RocDec.fromU64(340);
+    const number2: RocDec = RocDec.fromU64(340);
     try expectEqual(RocDec.fromU64(2), number1.div(number2));
 }
 
 test "div: 500 / 1000" {
     var number1: RocDec = RocDec.fromU64(500);
-    var number2: RocDec = RocDec.fromU64(1000);
-    var roc_str = RocStr.init("0.5", 3);
+    const number2: RocDec = RocDec.fromU64(1000);
+    const roc_str = RocStr.init("0.5", 3);
     try expectEqual(RocDec.fromStr(roc_str), number1.div(number2));
 }
 
@@ -1274,35 +1274,35 @@ test "log: 1" {
 }
 
 test "fract: 0" {
-    var roc_str = RocStr.init("0", 1);
+    const roc_str = RocStr.init("0", 1);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec{ .num = 0 }, dec.fract());
 }
 
 test "fract: 1" {
-    var roc_str = RocStr.init("1", 1);
+    const roc_str = RocStr.init("1", 1);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec{ .num = 0 }, dec.fract());
 }
 
 test "fract: 123.45" {
-    var roc_str = RocStr.init("123.45", 6);
+    const roc_str = RocStr.init("123.45", 6);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec{ .num = 450000000000000000 }, dec.fract());
 }
 
 test "fract: -123.45" {
-    var roc_str = RocStr.init("-123.45", 7);
+    const roc_str = RocStr.init("-123.45", 7);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec{ .num = -450000000000000000 }, dec.fract());
 }
 
 test "fract: .45" {
-    var roc_str = RocStr.init(".45", 3);
+    const roc_str = RocStr.init(".45", 3);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec{ .num = 450000000000000000 }, dec.fract());
@@ -1316,35 +1316,35 @@ test "fract: -0.00045" {
 }
 
 test "trunc: 0" {
-    var roc_str = RocStr.init("0", 1);
+    const roc_str = RocStr.init("0", 1);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec{ .num = 0 }, dec.trunc());
 }
 
 test "trunc: 1" {
-    var roc_str = RocStr.init("1", 1);
+    const roc_str = RocStr.init("1", 1);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec.one_point_zero, dec.trunc());
 }
 
 test "trunc: 123.45" {
-    var roc_str = RocStr.init("123.45", 6);
+    const roc_str = RocStr.init("123.45", 6);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec{ .num = 123000000000000000000 }, dec.trunc());
 }
 
 test "trunc: -123.45" {
-    var roc_str = RocStr.init("-123.45", 7);
+    const roc_str = RocStr.init("-123.45", 7);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec{ .num = -123000000000000000000 }, dec.trunc());
 }
 
 test "trunc: .45" {
-    var roc_str = RocStr.init(".45", 3);
+    const roc_str = RocStr.init(".45", 3);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec{ .num = 0 }, dec.trunc());
@@ -1358,64 +1358,64 @@ test "trunc: -0.00045" {
 }
 
 test "round: 123.45" {
-    var roc_str = RocStr.init("123.45", 6);
+    const roc_str = RocStr.init("123.45", 6);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec{ .num = 123000000000000000000 }, dec.round());
 }
 
 test "round: -123.45" {
-    var roc_str = RocStr.init("-123.45", 7);
+    const roc_str = RocStr.init("-123.45", 7);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec{ .num = -123000000000000000000 }, dec.round());
 }
 
 test "round: 0.5" {
-    var roc_str = RocStr.init("0.5", 3);
+    const roc_str = RocStr.init("0.5", 3);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec.one_point_zero, dec.round());
 }
 
 test "round: -0.5" {
-    var roc_str = RocStr.init("-0.5", 4);
+    const roc_str = RocStr.init("-0.5", 4);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec{ .num = -1000000000000000000 }, dec.round());
 }
 
 test "powInt: 3.1 ^ 0" {
-    var roc_str = RocStr.init("3.1", 3);
+    const roc_str = RocStr.init("3.1", 3);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(RocDec.one_point_zero, dec.powInt(0));
 }
 
 test "powInt: 3.1 ^ 1" {
-    var roc_str = RocStr.init("3.1", 3);
+    const roc_str = RocStr.init("3.1", 3);
     var dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(dec, dec.powInt(1));
 }
 
 test "powInt: 2 ^ 2" {
-    var roc_str = RocStr.init("4", 1);
-    var dec = RocDec.fromStr(roc_str).?;
+    const roc_str = RocStr.init("4", 1);
+    const dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(dec, RocDec.two_point_zero.powInt(2));
 }
 
 test "powInt: 0.5 ^ 2" {
-    var roc_str = RocStr.init("0.25", 4);
-    var dec = RocDec.fromStr(roc_str).?;
+    const roc_str = RocStr.init("0.25", 4);
+    const dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(dec, RocDec.zero_point_five.powInt(2));
 }
 
 test "pow: 0.5 ^ 2.0" {
-    var roc_str = RocStr.init("0.25", 4);
-    var dec = RocDec.fromStr(roc_str).?;
+    const roc_str = RocStr.init("0.25", 4);
+    const dec = RocDec.fromStr(roc_str).?;
 
     try expectEqual(dec, RocDec.zero_point_five.pow(RocDec.two_point_zero));
 }
@@ -1456,7 +1456,7 @@ pub fn toF64(arg: RocDec) callconv(.C) f64 {
 }
 
 pub fn exportFromInt(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T) callconv(.C) i128 {
             const this = @as(i128, @intCast(self));
 
@@ -1577,7 +1577,7 @@ pub fn mulSaturatedC(arg1: RocDec, arg2: RocDec) callconv(.C) RocDec {
 }
 
 pub fn exportRound(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: RocDec) callconv(.C) T {
             return @as(T, @intCast(@divFloor(input.round().num, RocDec.one_point_zero_i128)));
         }
@@ -1586,7 +1586,7 @@ pub fn exportRound(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportFloor(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: RocDec) callconv(.C) T {
             return @as(T, @intCast(@divFloor(input.floor().num, RocDec.one_point_zero_i128)));
         }
@@ -1595,7 +1595,7 @@ pub fn exportFloor(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportCeiling(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: RocDec) callconv(.C) T {
             return @as(T, @intCast(@divFloor(input.ceiling().num, RocDec.one_point_zero_i128)));
         }

--- a/package/zig-builtins/list.zig
+++ b/package/zig-builtins/list.zig
@@ -88,7 +88,7 @@ pub const RocList = extern struct {
             return RocList.empty();
         }
 
-        var list = allocate(@alignOf(T), slice.len, @sizeOf(T));
+        const list = allocate(@alignOf(T), slice.len, @sizeOf(T));
 
         if (slice.len > 0) {
             const dest = list.bytes orelse unreachable;
@@ -162,7 +162,7 @@ pub const RocList = extern struct {
         }
 
         // unfortunately, we have to clone
-        var new_list = RocList.allocate(alignment, self.length, element_width);
+        const new_list = RocList.allocate(alignment, self.length, element_width);
 
         var old_bytes: [*]u8 = @as([*]u8, @ptrCast(self.bytes));
         var new_bytes: [*]u8 = @as([*]u8, @ptrCast(new_list.bytes));
@@ -516,7 +516,7 @@ pub fn listReleaseExcessCapacity(
         list.decref(alignment);
         return RocList.empty();
     } else {
-        var output = RocList.allocateExact(alignment, old_length, element_width);
+        const output = RocList.allocateExact(alignment, old_length, element_width);
         if (list.bytes) |source_ptr| {
             const dest_ptr = output.bytes orelse unreachable;
 
@@ -844,7 +844,7 @@ fn swap(width_initial: usize, p1: [*]u8, p2: [*]u8) void {
     var ptr2 = p2;
 
     var buffer_actual: [threshold]u8 = undefined;
-    var buffer: [*]u8 = buffer_actual[0..];
+    const buffer: [*]u8 = buffer_actual[0..];
 
     while (true) {
         if (width < threshold) {
@@ -862,8 +862,8 @@ fn swap(width_initial: usize, p1: [*]u8, p2: [*]u8) void {
 }
 
 fn swapElements(source_ptr: [*]u8, element_width: usize, index_1: usize, index_2: usize) void {
-    var element_at_i = source_ptr + (index_1 * element_width);
-    var element_at_j = source_ptr + (index_2 * element_width);
+    const element_at_i = source_ptr + (index_1 * element_width);
+    const element_at_j = source_ptr + (index_2 * element_width);
 
     return swap(element_width, element_at_i, element_at_j);
 }
@@ -1018,7 +1018,7 @@ pub fn listAllocationPtr(
 
 test "listConcat: non-unique with unique overlapping" {
     var nonUnique = RocList.fromSlice(u8, ([_]u8{1})[0..]);
-    var bytes: [*]u8 = @as([*]u8, @ptrCast(nonUnique.bytes));
+    const bytes: [*]u8 = @as([*]u8, @ptrCast(nonUnique.bytes));
     const ptr_width = @sizeOf(usize);
     const refcount_ptr = @as([*]isize, @ptrCast(@as([*]align(ptr_width) u8, @alignCast(bytes)) - ptr_width));
     utils.increfRcPtrC(&refcount_ptr[0], 1);

--- a/package/zig-builtins/num.zig
+++ b/package/zig-builtins/num.zig
@@ -67,7 +67,7 @@ pub fn mul_u128(a: u128, b: u128) U256 {
 }
 
 pub fn exportParseInt(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(buf: RocStr) callconv(.C) NumParseResult(T) {
             // a radix of 0 will make zig determine the radix from the frefix:
             //  * A prefix of "0b" implies radix=2,
@@ -86,7 +86,7 @@ pub fn exportParseInt(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportParseFloat(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(buf: RocStr) callconv(.C) NumParseResult(T) {
             if (std.fmt.parseFloat(T, buf.asSlice())) |success| {
                 return .{ .errorcode = 0, .value = success };
@@ -99,7 +99,7 @@ pub fn exportParseFloat(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportNumToFloatCast(comptime T: type, comptime F: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(x: T) callconv(.C) F {
             return @floatFromInt(x);
         }
@@ -108,7 +108,7 @@ pub fn exportNumToFloatCast(comptime T: type, comptime F: type, comptime name: [
 }
 
 pub fn exportPow(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(base: T, exp: T) callconv(.C) T {
             return std.math.pow(T, base, exp);
         }
@@ -117,7 +117,7 @@ pub fn exportPow(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportIsNan(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: T) callconv(.C) bool {
             return std.math.isNan(input);
         }
@@ -126,7 +126,7 @@ pub fn exportIsNan(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportIsInfinite(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: T) callconv(.C) bool {
             return std.math.isInf(input);
         }
@@ -135,7 +135,7 @@ pub fn exportIsInfinite(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportIsFinite(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: T) callconv(.C) bool {
             return std.math.isFinite(input);
         }
@@ -144,7 +144,7 @@ pub fn exportIsFinite(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportAsin(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: T) callconv(.C) T {
             return std.math.asin(input);
         }
@@ -153,7 +153,7 @@ pub fn exportAsin(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportAcos(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: T) callconv(.C) T {
             return std.math.acos(input);
         }
@@ -162,7 +162,7 @@ pub fn exportAcos(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportAtan(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: T) callconv(.C) T {
             return std.math.atan(input);
         }
@@ -171,7 +171,7 @@ pub fn exportAtan(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportSin(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: T) callconv(.C) T {
             return math.sin(input);
         }
@@ -180,7 +180,7 @@ pub fn exportSin(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportCos(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: T) callconv(.C) T {
             return math.cos(input);
         }
@@ -189,7 +189,7 @@ pub fn exportCos(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportTan(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: T) callconv(.C) T {
             return math.tan(input);
         }
@@ -198,25 +198,25 @@ pub fn exportTan(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportLog(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: T) callconv(.C) T {
             return @log(input);
         }
     }.func;
     @export(f, .{ .name = name ++ @typeName(T), .linkage = .Strong });
 }
-
+/// Uses `@abs` as of Zig 0.12.0, which works for Integers too
 pub fn exportFAbs(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: T) callconv(.C) T {
-            return @fabs(input);
+            return @abs(input);
         }
     }.func;
     @export(f, .{ .name = name ++ @typeName(T), .linkage = .Strong });
 }
 
 pub fn exportSqrt(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: T) callconv(.C) T {
             return math.sqrt(input);
         }
@@ -225,7 +225,7 @@ pub fn exportSqrt(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportRound(comptime F: type, comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: F) callconv(.C) T {
             return @as(T, @intFromFloat((math.round(input))));
         }
@@ -234,7 +234,7 @@ pub fn exportRound(comptime F: type, comptime T: type, comptime name: []const u8
 }
 
 pub fn exportFloor(comptime F: type, comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: F) callconv(.C) T {
             return @as(T, @intFromFloat((math.floor(input))));
         }
@@ -243,7 +243,7 @@ pub fn exportFloor(comptime F: type, comptime T: type, comptime name: []const u8
 }
 
 pub fn exportCeiling(comptime F: type, comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: F) callconv(.C) T {
             return @as(T, @intFromFloat((math.ceil(input))));
         }
@@ -252,7 +252,7 @@ pub fn exportCeiling(comptime F: type, comptime T: type, comptime name: []const 
 }
 
 pub fn exportDivCeil(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(a: T, b: T) callconv(.C) T {
             return math.divCeil(T, a, b) catch {
                 roc_panic("Integer division by 0!", 0);
@@ -272,7 +272,7 @@ pub fn ToIntCheckedResult(comptime T: type) type {
 }
 
 pub fn exportToIntCheckingMax(comptime From: type, comptime To: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: From) callconv(.C) ToIntCheckedResult(To) {
             if (input > std.math.maxInt(To)) {
                 return .{ .out_of_bounds = true, .value = 0 };
@@ -284,7 +284,7 @@ pub fn exportToIntCheckingMax(comptime From: type, comptime To: type, comptime n
 }
 
 pub fn exportToIntCheckingMaxAndMin(comptime From: type, comptime To: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(input: From) callconv(.C) ToIntCheckedResult(To) {
             if (input > std.math.maxInt(To) or input < std.math.minInt(To)) {
                 return .{ .out_of_bounds = true, .value = 0 };
@@ -311,7 +311,7 @@ fn isMultipleOf(comptime T: type, lhs: T, rhs: T) bool {
 }
 
 pub fn exportIsMultipleOf(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T, other: T) callconv(.C) bool {
             return @call(.always_inline, isMultipleOf, .{ T, self, other });
         }
@@ -334,7 +334,7 @@ fn addWithOverflow(comptime T: type, self: T, other: T) WithOverflow(T) {
 }
 
 pub fn exportAddWithOverflow(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T, other: T) callconv(.C) WithOverflow(T) {
             return @call(.always_inline, addWithOverflow, .{ T, self, other });
         }
@@ -343,7 +343,7 @@ pub fn exportAddWithOverflow(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportAddSaturatedInt(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T, other: T) callconv(.C) T {
             const result = addWithOverflow(T, self, other);
             if (result.has_overflowed) {
@@ -362,7 +362,7 @@ pub fn exportAddSaturatedInt(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportAddOrPanic(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T, other: T) callconv(.C) T {
             const result = addWithOverflow(T, self, other);
             if (result.has_overflowed) {
@@ -390,7 +390,7 @@ fn subWithOverflow(comptime T: type, self: T, other: T) WithOverflow(T) {
 }
 
 pub fn exportSubWithOverflow(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T, other: T) callconv(.C) WithOverflow(T) {
             return @call(.always_inline, subWithOverflow, .{ T, self, other });
         }
@@ -399,7 +399,7 @@ pub fn exportSubWithOverflow(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportSubSaturatedInt(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T, other: T) callconv(.C) T {
             const result = subWithOverflow(T, self, other);
             if (result.has_overflowed) {
@@ -419,7 +419,7 @@ pub fn exportSubSaturatedInt(comptime T: type, comptime name: []const u8) void {
 }
 
 pub fn exportSubOrPanic(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T, other: T) callconv(.C) T {
             const result = subWithOverflow(T, self, other);
             if (result.has_overflowed) {
@@ -440,29 +440,8 @@ fn mulWithOverflow(comptime T: type, comptime W: type, self: T, other: T) WithOv
                 const max = std.math.maxInt(i128);
                 const min = std.math.minInt(i128);
 
-                const self_u128 = @as(u128, @intCast(math.absInt(self) catch {
-                    if (other == 0) {
-                        return .{ .value = 0, .has_overflowed = false };
-                    } else if (other == 1) {
-                        return .{ .value = self, .has_overflowed = false };
-                    } else if (is_answer_negative) {
-                        return .{ .value = min, .has_overflowed = true };
-                    } else {
-                        return .{ .value = max, .has_overflowed = true };
-                    }
-                }));
-
-                const other_u128 = @as(u128, @intCast(math.absInt(other) catch {
-                    if (self == 0) {
-                        return .{ .value = 0, .has_overflowed = false };
-                    } else if (self == 1) {
-                        return .{ .value = other, .has_overflowed = false };
-                    } else if (is_answer_negative) {
-                        return .{ .value = min, .has_overflowed = true };
-                    } else {
-                        return .{ .value = max, .has_overflowed = true };
-                    }
-                }));
+                const self_u128 = @abs(self);
+                const other_u128 = @abs(other);
 
                 const answer256: U256 = mul_u128(self_u128, other_u128);
 
@@ -507,7 +486,7 @@ fn mulWithOverflow(comptime T: type, comptime W: type, self: T, other: T) WithOv
 }
 
 pub fn exportMulWithOverflow(comptime T: type, comptime W: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T, other: T) callconv(.C) WithOverflow(T) {
             return @call(.always_inline, mulWithOverflow, .{ T, W, self, other });
         }
@@ -516,7 +495,7 @@ pub fn exportMulWithOverflow(comptime T: type, comptime W: type, comptime name: 
 }
 
 pub fn exportMulSaturatedInt(comptime T: type, comptime W: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T, other: T) callconv(.C) T {
             const result = @call(.always_inline, mulWithOverflow, .{ T, W, self, other });
             return result.value;
@@ -526,7 +505,7 @@ pub fn exportMulSaturatedInt(comptime T: type, comptime W: type, comptime name: 
 }
 
 pub fn exportMulWrappedInt(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T, other: T) callconv(.C) T {
             return self *% other;
         }
@@ -603,7 +582,7 @@ pub fn greaterThanOrEqualU128(self: u128, other: u128) callconv(.C) bool {
 }
 
 pub fn exportMulOrPanic(comptime T: type, comptime W: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T, other: T) callconv(.C) T {
             const result = @call(.always_inline, mulWithOverflow, .{ T, W, self, other });
             if (result.has_overflowed) {
@@ -617,7 +596,7 @@ pub fn exportMulOrPanic(comptime T: type, comptime W: type, comptime name: []con
 }
 
 pub fn exportCountLeadingZeroBits(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T) callconv(.C) u8 {
             return @as(u8, @clz(self));
         }
@@ -626,7 +605,7 @@ pub fn exportCountLeadingZeroBits(comptime T: type, comptime name: []const u8) v
 }
 
 pub fn exportCountTrailingZeroBits(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T) callconv(.C) u8 {
             return @as(u8, @ctz(self));
         }
@@ -635,7 +614,7 @@ pub fn exportCountTrailingZeroBits(comptime T: type, comptime name: []const u8) 
 }
 
 pub fn exportCountOneBits(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(self: T) callconv(.C) u8 {
             return @as(u8, @popCount(self));
         }

--- a/package/zig-builtins/str.zig
+++ b/package/zig-builtins/str.zig
@@ -212,7 +212,7 @@ pub const RocStr = extern struct {
             // just return the bytes
             return str;
         } else {
-            var new_str = RocStr.allocateBig(str.length, str.length);
+            const new_str = RocStr.allocateBig(str.length, str.length);
 
             var old_bytes: [*]u8 = @as([*]u8, @ptrCast(str.bytes));
             var new_bytes: [*]u8 = @as([*]u8, @ptrCast(new_str.bytes));
@@ -273,7 +273,7 @@ pub const RocStr = extern struct {
             const source_ptr = self.asU8ptr();
             const dest_ptr = result.asU8ptrMut();
 
-            std.mem.copy(u8, dest_ptr[0..old_length], source_ptr[0..old_length]);
+            std.mem.copyForwards(u8, dest_ptr[0..old_length], source_ptr[0..old_length]);
             @memset(dest_ptr[old_length..new_length], 0);
 
             self.decref();
@@ -289,7 +289,7 @@ pub const RocStr = extern struct {
 
             const source_ptr = self.asU8ptr();
 
-            std.mem.copy(u8, dest_ptr[0..old_length], source_ptr[0..old_length]);
+            std.mem.copyForwards(u8, dest_ptr[0..old_length], source_ptr[0..old_length]);
             @memset(dest_ptr[old_length..new_length], 0);
 
             self.decref();
@@ -553,7 +553,7 @@ pub fn strNumberOfBytes(string: RocStr) callconv(.C) usize {
 
 // Str.fromInt
 pub fn exportFromInt(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(int: T) callconv(.C) RocStr {
             return @call(.always_inline, strFromIntHelp, .{ T, int });
         }
@@ -567,9 +567,9 @@ fn strFromIntHelp(comptime T: type, int: T) RocStr {
     const size = comptime blk: {
         // the string representation of the minimum i128 value uses at most 40 characters
         var buf: [40]u8 = undefined;
-        var resultMin = std.fmt.bufPrint(&buf, "{}", .{std.math.minInt(T)}) catch unreachable;
-        var resultMax = std.fmt.bufPrint(&buf, "{}", .{std.math.maxInt(T)}) catch unreachable;
-        var result = if (resultMin.len > resultMax.len) resultMin.len else resultMax.len;
+        const resultMin = std.fmt.bufPrint(&buf, "{}", .{std.math.minInt(T)}) catch unreachable;
+        const resultMax = std.fmt.bufPrint(&buf, "{}", .{std.math.maxInt(T)}) catch unreachable;
+        const result = if (resultMin.len > resultMax.len) resultMin.len else resultMax.len;
         break :blk result;
     };
 
@@ -581,7 +581,7 @@ fn strFromIntHelp(comptime T: type, int: T) RocStr {
 
 // Str.fromFloat
 pub fn exportFromFloat(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(float: T) callconv(.C) RocStr {
             return @call(.always_inline, strFromFloatHelp, .{ T, float });
         }
@@ -661,7 +661,7 @@ test "strSplitHelp: empty delimiter" {
 
     strSplitHelp(array_ptr, str, delimiter);
 
-    var expected = [1]RocStr{
+    const expected = [1]RocStr{
         str,
     };
 
@@ -695,7 +695,7 @@ test "strSplitHelp: no delimiter" {
 
     strSplitHelp(array_ptr, str, delimiter);
 
-    var expected = [1]RocStr{
+    const expected = [1]RocStr{
         str,
     };
 
@@ -734,7 +734,7 @@ test "strSplitHelp: empty start" {
 
     const one = RocStr.init("a", 1);
 
-    var expected = [2]RocStr{
+    const expected = [2]RocStr{
         RocStr.empty(), one,
     };
 
@@ -776,7 +776,7 @@ test "strSplitHelp: empty end" {
     const one = RocStr.init("1", 1);
     const two = RocStr.init("2", 1);
 
-    var expected = [3]RocStr{
+    const expected = [3]RocStr{
         one, two, RocStr.empty(),
     };
 
@@ -812,7 +812,7 @@ test "strSplitHelp: string equals delimiter" {
 
     strSplitHelp(array_ptr, str_delimiter, str_delimiter);
 
-    var expected = [2]RocStr{ RocStr.empty(), RocStr.empty() };
+    const expected = [2]RocStr{ RocStr.empty(), RocStr.empty() };
 
     defer {
         for (array) |rocStr| {
@@ -850,7 +850,7 @@ test "strSplitHelp: delimiter on sides" {
     const ghi_arr = "ghi";
     const ghi = RocStr.init(ghi_arr, ghi_arr.len);
 
-    var expected = [3]RocStr{
+    const expected = [3]RocStr{
         RocStr.empty(), ghi, RocStr.empty(),
     };
 
@@ -891,7 +891,7 @@ test "strSplitHelp: three pieces" {
     const b = RocStr.init("b", 1);
     const c = RocStr.init("c", 1);
 
-    var expected_array = [array_len]RocStr{
+    const expected_array = [array_len]RocStr{
         a, b, c,
     };
 
@@ -927,7 +927,7 @@ test "strSplitHelp: overlapping delimiter 1" {
 
     strSplitHelp(array_ptr, str, delimiter);
 
-    var expected = [2]RocStr{
+    const expected = [2]RocStr{
         RocStr.empty(),
         RocStr.init("a", 1),
     };
@@ -952,7 +952,7 @@ test "strSplitHelp: overlapping delimiter 2" {
 
     strSplitHelp(array_ptr, str, delimiter);
 
-    var expected = [3]RocStr{
+    const expected = [3]RocStr{
         RocStr.empty(),
         RocStr.empty(),
         RocStr.empty(),
@@ -1363,7 +1363,7 @@ fn strJoinWith(list: RocListStr, separator: RocStr) RocStr {
         total_size += separator.len() * (len - 1);
 
         var result = RocStr.allocate(total_size);
-        var result_ptr = result.asU8ptrMut();
+        const result_ptr = result.asU8ptrMut();
 
         var offset: usize = 0;
         for (slice[0 .. len - 1]) |substr| {
@@ -1942,7 +1942,7 @@ pub fn strTrimEnd(input_string: RocStr) callconv(.C) RocStr {
 fn countLeadingWhitespaceBytes(string: RocStr) usize {
     var byte_count: usize = 0;
 
-    var bytes = string.asU8ptr()[0..string.len()];
+    const bytes = string.asU8ptr()[0..string.len()];
     var iter = unicode.Utf8View.initUnchecked(bytes).iterator();
     while (iter.nextCodepoint()) |codepoint| {
         if (isWhitespace(codepoint)) {
@@ -1958,7 +1958,7 @@ fn countLeadingWhitespaceBytes(string: RocStr) usize {
 fn countTrailingWhitespaceBytes(string: RocStr) usize {
     var byte_count: usize = 0;
 
-    var bytes = string.asU8ptr()[0..string.len()];
+    const bytes = string.asU8ptr()[0..string.len()];
     var iter = ReverseUtf8View.initUnchecked(bytes).iterator();
     while (iter.nextCodepoint()) |codepoint| {
         if (isWhitespace(codepoint)) {


### PR DESCRIPTION
# Update Zig Builtins for compatibility with Zig 0.12

Changes: 

- Change `var` declarations to `const` where value is not mutated (now a compiler error).
- Similarly, `comptime var f = struct {...` becomes `const f = comptime struct {...`.
- Change calls to `std.mem.copy` to `std.mem.copyForwards`.
- Use `@abs` instead of `@fabs` and `std.math.absInt`. Need to make sure `mulWithOverflow` still works correctly with `i128`. 

How do I verify the last change is correct?

Should we go ahead and make sure this works with Zig 0.13 now that it's been released?